### PR TITLE
Make StructureGenerateEvent fire async if it's configured to

### DIFF
--- a/patches/api/0010-Make-StructureGenerateEvent-fire-async-if-it-s-confi.patch
+++ b/patches/api/0010-Make-StructureGenerateEvent-fire-async-if-it-s-confi.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nahuel <nahueldolores@hotmail.com>
+Date: Thu, 28 May 2020 21:42:36 -0300
+Subject: [PATCH] Make StructureGenerateEvent fire async if it's configured to
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/world/StructureGenerateEvent.java b/src/main/java/com/destroystokyo/paper/event/world/StructureGenerateEvent.java
+index e00d5a598ca2eb1fb14a41712f155fb506546498..3f3d9416e4a335045c71eecca2298892dc146b6d 100644
+--- a/src/main/java/com/destroystokyo/paper/event/world/StructureGenerateEvent.java
++++ b/src/main/java/com/destroystokyo/paper/event/world/StructureGenerateEvent.java
+@@ -18,8 +18,8 @@ public class StructureGenerateEvent extends Event implements Cancellable {
+ 
+     private boolean cancel = false;
+ 
+-    public StructureGenerateEvent(@NotNull World world, @NotNull StructureType structureType, int chunkX, int chunkZ) {
+-        super(true);
++    public StructureGenerateEvent(boolean async, @NotNull World world, @NotNull StructureType structureType, int chunkX, int chunkZ) {
++        super(async);
+         this.world = Preconditions.checkNotNull(world, "world");
+         this.structureType = Preconditions.checkNotNull(structureType, "structureType");
+         this.chunkX = chunkX;

--- a/patches/server/0012-Make-StructureGenerateEvent-fire-async-if-it-s-confi.patch
+++ b/patches/server/0012-Make-StructureGenerateEvent-fire-async-if-it-s-confi.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nahuel <nahueldolores@hotmail.com>
+Date: Thu, 28 May 2020 21:42:35 -0300
+Subject: [PATCH] Make StructureGenerateEvent fire async if it's configured to
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkGenerator.java b/src/main/java/net/minecraft/server/ChunkGenerator.java
+index bcc02502c589644983badd45b068bb1624f2f495..5f07359cfe39d92d473b9267102a64e4d1f63f41 100644
+--- a/src/main/java/net/minecraft/server/ChunkGenerator.java
++++ b/src/main/java/net/minecraft/server/ChunkGenerator.java
+@@ -1,6 +1,7 @@
+ package net.minecraft.server;
+ 
+ // Papercut start
++import com.destroystokyo.paper.PaperConfig;
+ import com.destroystokyo.paper.event.world.StructureGenerateEvent;
+ import org.bukkit.StructureType;
+ // Papercut end
+@@ -176,6 +177,7 @@ public abstract class ChunkGenerator<C extends GeneratorSettingsDefault> {
+     // Papercut start
+     private StructureStart getStructureStart(BiomeManager biomemanager, ChunkGenerator<?> chunkgenerator, DefinedStructureManager definedstructuremanager, StructureGenerator<?> structuregenerator, int i, SeededRandom seededrandom, ChunkCoordIntPair chunkcoordintpair, StructureStart structurestart1, BiomeBase biomebase) {
+         StructureGenerateEvent event = new StructureGenerateEvent(
++                PaperConfig.asyncChunks && !getWorld().getServer().isPrimaryThread(),
+                 getWorld().getWorld(),
+                 StructureType.getStructureTypes().get(structuregenerator.b().toLowerCase()),
+                 chunkcoordintpair.x,


### PR DESCRIPTION
I had some troubles with the event throwing exceptions when it was run with a server that had async chunk loading turned off.
Hopefully this should solve the issue.